### PR TITLE
docs: fix example

### DIFF
--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -7,6 +7,8 @@
 缓存服务的用法非常简单：
 
 ```ts
+import {} from "@koishijs/cache";
+
 // 扩展 foo 表
 declare module '@koishijs/cache' {
   interface Tables {

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -7,7 +7,7 @@
 缓存服务的用法非常简单：
 
 ```ts
-import {} from "@koishijs/cache";
+import {} from '@koishijs/cache'
 
 // 扩展 foo 表
 declare module '@koishijs/cache' {


### PR DESCRIPTION
Add import for basic example. This should prevent "module not found" error (TS2664) when declaring modules.